### PR TITLE
Fix tab management and uniform column widths

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,30 +32,33 @@ function App() {
   const activeTab = tabs.find(tab => tab.id === activeTabId)!
 
   const addTab = () => {
-    const newTab: QueryTab = {
-      id: `tab-${Date.now()}`,
-      name: `Query ${tabs.length + 1}`,
-      query: 'SELECT * FROM employees',
-      result: null,
-      isExecuting: false,
-    }
-    setTabs([...tabs, newTab])
-    setActiveTabId(newTab.id)
+    const id = `tab-${Date.now()}`
+    setTabs(prev => {
+      const newTab: QueryTab = {
+        id,
+        name: `Query ${prev.length + 1}`,
+        query: 'SELECT * FROM employees',
+        result: null,
+        isExecuting: false,
+      }
+      return [...prev, newTab]
+    })
+    setActiveTabId(id)
   }
 
   const closeTab = (tabId: string) => {
-    if (tabs.length === 1) return
-    const newTabs = tabs.filter(t => t.id !== tabId)
-    setTabs(newTabs)
-    if (activeTabId === tabId) {
-      setActiveTabId(newTabs[0].id)
-    }
+    setTabs(prevTabs => {
+      if (prevTabs.length === 1) return prevTabs
+      const newTabs = prevTabs.filter(t => t.id !== tabId)
+      setActiveTabId(prevActive => (prevActive === tabId ? newTabs[0].id : prevActive))
+      return newTabs
+    })
   }
 
   const updateTab = (tabId: string, updates: Partial<QueryTab>) => {
-    setTabs(tabs.map(tab => 
-      tab.id === tabId ? { ...tab, ...updates } : tab
-    ))
+    setTabs(prevTabs =>
+      prevTabs.map(tab => (tab.id === tabId ? { ...tab, ...updates } : tab))
+    )
   }
 
   const handleExecuteQuery = () => {

--- a/src/components/features/DataTable.tsx
+++ b/src/components/features/DataTable.tsx
@@ -70,9 +70,9 @@ export function DataTable({ result, isLoading }: DataTableProps) {
           </span>
         )
       },
-      size: undefined, // Auto-size columns based on content
-      minSize: 120,    // Minimum column width
-      maxSize: 300,    // Maximum column width  
+      size: 150,
+      minSize: 150,
+      maxSize: 150,
     }))
   }, [result])
 
@@ -188,7 +188,7 @@ export function DataTable({ result, isLoading }: DataTableProps) {
             }}
           >
             <div style={{ height: `${virtualizer.getTotalSize()}px`, minWidth: 'max-content' }} className="relative">
-              <table style={{ minWidth: 'max-content', width: '100%' }}>
+              <table className="table-fixed" style={{ minWidth: 'max-content', width: '100%' }}>
                   <thead className="sticky top-0 z-10 bg-background border-b">
                     {table.getHeaderGroups().map(headerGroup => (
                       <tr key={headerGroup.id}>


### PR DESCRIPTION
## Summary
- ensure new tabs and query edits update state reliably
- give data table columns a consistent width for easier reading

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint found too many warnings)*
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b95ffd1b9c8328a22692172033a2be